### PR TITLE
Update broken link to `amending-a-commit-guide.md`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -5,4 +5,4 @@ Please note that this project is released with a [Contributor Code of Conduct](c
 
 ## Updating your pull request
 
-Sometimes a maintainer will ask you to edit your pull request before it's included. This is normally due to spelling errors or because your pull request didn't match the guidelines. [Here](https://github.com/RichardLitt/docs/blob/master/amending-a-commit-guide.md) is a write-up on how to update your pull request.
+Sometimes a maintainer will ask you to edit your pull request before it's included. This is normally due to spelling errors or because your pull request didn't match the guidelines. [Here](https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md) is a write-up on how to update your pull request.


### PR DESCRIPTION
Update broken link to `amending-a-commit-guide.md`. There is [600+](https://github.com/search?l=Markdown&q=RichardLitt%2Fdocs%2Fblob%2Fmaster%2Famending-a-commit-guide.md&type=Code&utf8=%E2%9C%93) other references to the old link! 😨